### PR TITLE
Add filter component for pagination of the Jobs frontend

### DIFF
--- a/frontend/src/main/components/Jobs/JobsSearchForm.js
+++ b/frontend/src/main/components/Jobs/JobsSearchForm.js
@@ -1,0 +1,47 @@
+import { Container, Row, Col } from "react-bootstrap";
+import GenericDropdown from "main/components/Utils/GenericDropdown";
+
+const JobsSearchForm = ({
+  updateSortField,
+  updateSortDirection,
+  updatePageSize,
+}) => {
+  // Stryker disable all ; testing for specific hard coded lists is just writing the code twice
+  const sortFields = ["createdAt", "updatedAt", "status"];
+  const sortDirections = ["ASC", "DESC"];
+  const pageSizes = ["5", "10", "50", "100"];
+  // Stryker restore all
+
+  return (
+    <Container>
+      <Row>
+        <Col md="auto">
+          <GenericDropdown
+            values={sortFields}
+            setValue={updateSortField}
+            controlId={"JobsSearch.SortField"}
+            label="Sort By"
+          />
+        </Col>
+        <Col md="auto">
+          <GenericDropdown
+            values={sortDirections}
+            setValue={updateSortDirection}
+            controlId={"JobsSearch.SortDirection"}
+            label="Sort Direction"
+          />
+        </Col>
+        <Col md="auto">
+          <GenericDropdown
+            values={pageSizes}
+            setValue={updatePageSize}
+            controlId={"JobsSearch.PageSize"}
+            label="Page Size"
+          />
+        </Col>
+      </Row>
+    </Container>
+  );
+};
+
+export default JobsSearchForm;

--- a/frontend/src/main/components/Jobs/JobsSearchForm.js
+++ b/frontend/src/main/components/Jobs/JobsSearchForm.js
@@ -1,10 +1,13 @@
 import { Container, Row, Col } from "react-bootstrap";
 import GenericDropdown from "main/components/Utils/GenericDropdown";
+import OurPagination from "../Utils/OurPagination";
 
 const JobsSearchForm = ({
+  updateSelectedPage,
   updateSortField,
   updateSortDirection,
   updatePageSize,
+  totalPages,
 }) => {
   // Stryker disable all ; testing for specific hard coded lists is just writing the code twice
   const sortFields = ["createdAt", "updatedAt", "status"];
@@ -40,6 +43,10 @@ const JobsSearchForm = ({
           />
         </Col>
       </Row>
+      <OurPagination
+        updateActivePage={updateSelectedPage}
+        totalPages={totalPages}
+      />
     </Container>
   );
 };

--- a/frontend/src/stories/components/Jobs/JobsSearchForm.stories.js
+++ b/frontend/src/stories/components/Jobs/JobsSearchForm.stories.js
@@ -1,0 +1,23 @@
+import JobsSearchForm from "main/components/Jobs/JobsSearchForm";
+
+export default {
+  title: "components/Jobs/JobsSearchForm",
+  component: JobsSearchForm,
+};
+
+const Template = (args) => {
+  return <JobsSearchForm {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  updateSortField: (s) => {
+    console.log(`updateSortField: ${s}`);
+  },
+  updateSortDirection: (s) => {
+    console.log(`updateSortDirection: ${s}`);
+  },
+  updatePageSize: (s) => {
+    console.log(`updatePageSize: ${s}`);
+  },
+};

--- a/frontend/src/tests/components/Jobs/JobsSearchForm.test.js
+++ b/frontend/src/tests/components/Jobs/JobsSearchForm.test.js
@@ -2,7 +2,6 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import UpdatesSearchForm from "main/components/Jobs/JobsSearchForm";
 import JobsSearchForm from "main/components/Jobs/JobsSearchForm";
 
 describe("JobsSearchForm tests", () => {
@@ -90,7 +89,7 @@ describe("JobsSearchForm tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <UpdatesSearchForm
+          <JobsSearchForm
             updateSortDirection={updateSortDirection}
             updateSortField={updateSortField}
             updatePageSize={updatePageSize}

--- a/frontend/src/tests/components/Jobs/JobsSearchForm.test.js
+++ b/frontend/src/tests/components/Jobs/JobsSearchForm.test.js
@@ -1,0 +1,107 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import UpdatesSearchForm from "main/components/Jobs/JobsSearchForm";
+import JobsSearchForm from "main/components/Jobs/JobsSearchForm";
+
+describe("JobsSearchForm tests", () => {
+  const queryClient = new QueryClient();
+
+  const updateSortField = jest.fn();
+  const updateSortDirection = jest.fn();
+  const updatePageSize = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "error");
+    console.error.mockImplementation(() => null);
+  });
+
+  test("when I select a sortField, the state for sortField changes", () => {
+    const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <JobsSearchForm
+            updateSortDirection={updateSortDirection}
+            updateSortField={updateSortField}
+            updatePageSize={updatePageSize}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    const selectSortField = screen.getByLabelText("Sort By");
+    userEvent.selectOptions(selectSortField, "status");
+    expect(selectSortField.value).toBe("status");
+    expect(setItemSpy).toHaveBeenCalledWith("JobsSearch.SortField", "status");
+  });
+
+  test("when I select a sortDirection, the state for sortDirection changes", () => {
+    const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <JobsSearchForm
+            updateSortDirection={updateSortDirection}
+            updateSortField={updateSortField}
+            updatePageSize={updatePageSize}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    const selectSortDirection = screen.getByLabelText("Sort Direction");
+    userEvent.selectOptions(selectSortDirection, "DESC");
+    expect(selectSortDirection.value).toBe("DESC");
+    expect(setItemSpy).toHaveBeenCalledWith("JobsSearch.SortDirection", "DESC");
+
+    userEvent.selectOptions(selectSortDirection, "DESC");
+    expect(selectSortDirection.value).toBe("DESC");
+    expect(setItemSpy).toHaveBeenCalledWith("JobsSearch.SortDirection", "DESC");
+  });
+
+  test("when I select a pageSize, the state for pageSize changes", () => {
+    const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <JobsSearchForm
+            updateSortDirection={updateSortDirection}
+            updateSortField={updateSortField}
+            updatePageSize={updatePageSize}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    const selectPageSize = screen.getByLabelText("Page Size");
+    userEvent.selectOptions(selectPageSize, "10");
+    expect(selectPageSize.value).toBe("10");
+    expect(setItemSpy).toHaveBeenCalledWith("JobsSearch.PageSize", "10");
+  });
+
+  test("renders correctly when fallback values are used", async () => {
+    const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
+    getItemSpy.mockImplementation(() => null);
+    const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UpdatesSearchForm
+            updateSortDirection={updateSortDirection}
+            updateSortField={updateSortField}
+            updatePageSize={updatePageSize}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const setItemCalls = setItemSpy.mock.calls;
+    expect(setItemCalls).toContainEqual(["JobsSearch.SortField", "createdAt"]);
+    expect(setItemCalls).toContainEqual(["JobsSearch.SortDirection", "ASC"]);
+    expect(setItemCalls).toContainEqual(["JobsSearch.PageSize", "5"]);
+  });
+});


### PR DESCRIPTION
Closes #32 

In this PR, I create a component (along with tests and storybook) to modify Job Table pagination parameters. It has fields "Sort By", "Sort Direction", "Page Size", and a field to select the page index. 

Here is the link to the storybook: https://6823eb7c97d050007941c802-zqvjermfva.chromatic.com/?path=/story/components-jobs-jobssearchform--default

<img width="363" alt="Screenshot 2025-05-17 at 5 47 18 PM" src="https://github.com/user-attachments/assets/1dd70880-2914-491f-9f09-138591980a4a" />

